### PR TITLE
Fix: support ExecutionResult::I16 variant thru re-use of Byte

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -849,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "qcs-sdk-c"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "eyre",
  "http",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -356,7 +356,6 @@ impl From<Vec<Vec<i16>>> for ExecutionData {
             })
             .collect();
 
-        // TODO: consider different `DataType` variant here, rather than re-use of smaller `Byte`
         #[allow(clippy::cast_possible_truncation)]
         Self {
             data: DataType::Byte(ManuallyDrop::new(results).as_mut_ptr().cast::<*mut i8>()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -359,7 +359,7 @@ impl From<Vec<Vec<i16>>> for ExecutionData {
         // TODO: consider different `DataType` variant here, rather than re-use of smaller `Byte`
         #[allow(clippy::cast_possible_truncation)]
         Self {
-            data: DataType::Byte(ManuallyDrop::new(results).as_mut_ptr() as *mut *mut c_char),
+            data: DataType::Byte(ManuallyDrop::new(results).as_mut_ptr().cast::<*mut i8>()),
             number_of_shots,
             shot_length,
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -267,7 +267,7 @@ impl ExecutionData {
             qcs::ExecutionResult::I8(data) => Some(ExecutionData::from(data)),
             qcs::ExecutionResult::I16(data) => Some(ExecutionData::from(data)),
             qcs::ExecutionResult::F64(data) => Some(ExecutionData::from(data)),
-            _ => None,
+            qcs::ExecutionResult::Complex32(_) => None,
         }
     }
 


### PR DESCRIPTION
Quickfix for accessing readout results from `qcs-sdk-qir`-compiled programs. 